### PR TITLE
sort filenames to preserve name ordering so that md5 signature preserved

### DIFF
--- a/lib/handlebar-rider.js
+++ b/lib/handlebar-rider.js
@@ -178,6 +178,8 @@ fs = require('fs');
     
     //read files in the directory
     readTemplatesDirectory(dir, function(err, files) {
+      // sort filenames to preserve ordering in generated files (so that re-running the script does not produce different md5 sigature)
+      files.sort();
     
      try {
        


### PR DESCRIPTION
Hello, 

We found that repeatedly calling handlebar-rider compile() on unchanged js templates produced an output file with changing md5 signatures.  A simple sort on the directory file list before adding them to the template hash seems to have solved the problem.
