### PR TITLE
Urgent: Package.json fix for fatal install bug

### DIFF
--- a/lib/handlebar-rider.js
+++ b/lib/handlebar-rider.js
@@ -138,7 +138,8 @@ var optimist = require('optimist')
   }
 
   var precompile = function(data) {
-    if( data == data || "" )
+    data = data || "";
+    if(data == "")
       return "";
     else
       return handlebars.precompile( data, {});

--- a/lib/handlebar-rider.js
+++ b/lib/handlebar-rider.js
@@ -6,6 +6,7 @@ var optimist = require('optimist')
   , scli = require('supercli')
   , __ = require('underscore')
   , watch = require('watch')
+  , async = require('async')
   ;
 
 (function(){
@@ -314,6 +315,9 @@ exports.run = function(){
     .alias('r','readable')
     .describe('r','Make the output more readable by avoiding default minification')
     .default('r', false)
+    .alias('e','extensions')
+    .describe('e','Add more extensions to the defaults for templates that Handlebar-Rider will compile')
+    .default('e','["hb","hbs","handlebars","template","templates","tpl","item","part","prt","pt"]')
   .argv
   
   dir = argv.in;
@@ -333,7 +337,7 @@ exports.run = function(){
 }
 
 // export functions for module use
-exports.configure = function(config){ rider = config; }
+exports.configure = function(config){ __.extend(rider,config) }
 exports.watch = function(){
   
   scli.warn('Watching template directory "' + rider.in + '"');
@@ -350,6 +354,3 @@ exports.compile = function(){
 
  
 })()
-
-
-

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "handlebars"  : ">= 1.x",
     "uglify-js"   : "1.1.1",
     "optimist"    : ">= 0.3.4",
-    "supercli"    : "*"
+    "supercli"    : "*",
+    "underscore"  : "*",
+    "watch"       : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
     "node"           : ">= 0.4.9"
   },
   
-  "dependencies"   : {
-    "handlebars"  : ">= 1.x",
-    "uglify-js"   : "1.1.1",
-    "optimist"    : ">= 0.3.4",
-    "supercli"    : "*"
+  "dependencies" : {
+    "handlebars" : ">= 1.x",
+    "uglify-js" : "1.1.1",
+    "optimist" : ">= 0.3.4",
+    "supercli" : "*",
+    "underscore" : "*",
+    "watch" : "*",
+    "async" : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "handlebars"  : ">= 1.x",
     "uglify-js"   : "1.1.1",
     "optimist"    : ">= 0.3.4",
-    "supercli"    : "*",
-    "underscore"  : "*",
-    "watch"       : "*"
+    "supercli"    : "*"
   }
 }


### PR DESCRIPTION
Because I'm a fucking moron and didn't include the dependencies in package.json when I submitted my last pull request. I already had these node modules installed globally and it didn't throw any errors for me because of that, but installing handlebar-rider on a fresh folder threw multiple dependency failures because I failed to update package.json.

Sorry :-/

**EDIT:** Yeah... Because of a HUGE logic error that I just found, templates were actually being returned as empty strings no matter what. I have fixed that bug (that I caused) and it's here in this pull request as well.
