### PR TITLE
Windows array slugs were using "\" instead of "/"

### DIFF
--- a/lib/handlebar-rider.js
+++ b/lib/handlebar-rider.js
@@ -200,7 +200,7 @@ var optimist = require('optimist')
                 if(needsCompile(ext)) {
                   var relpath = path.relative(rider.in, file.name)
                   var newTemplate = {
-                    namespace : relpath.replace(ext,'').replace("\\","/"),
+                    namespace : relpath.replace(ext,'').replace(/\\/g,"/"),
                     file : file.name
                   };
                   rider.templates.push(newTemplate);


### PR DESCRIPTION
The regex only replaced the first occurance of a windows directory
separator.
